### PR TITLE
Allow use of an existing Lustre for FSx filesystem

### DIFF
--- a/examples/kubernetes/dynamic_provisioning_existing_fs/README.md
+++ b/examples/kubernetes/dynamic_provisioning_existing_fs/README.md
@@ -1,0 +1,54 @@
+## Dynamic Provisioning Example
+This example shows how to use an existing FSx for Lustre filesystem using persistence volume claim (PVC) and consumes it from a pod.
+Each PVC will create a separate folder at the root of the filesystem.
+Update the parameters to match your filesystem.
+
+### Edit [StorageClass](./specs/storageclass.yaml)
+```
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fsx-sc-0d3a
+provisioner: fsx.csi.aws.com
+parameters:
+  fileSystemId: fs-0d3a9c1160a2ef4ad
+mountOptions:
+  - flock
+```
+
+### Edit [Persistent Volume Claim Spec](./specs/claim.yaml)
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc-03da
+  resources:
+    requests:
+      storage: 6000Gi
+```
+NOTE: `spec.resource.requests.storage` is not used at this time. It must be managed outside of kubernetes.
+
+### Deploy the Application
+Create PVC, storageclass and the pod that consumes the PV:
+```sh
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning_existing_fs/specs/storageclass.yaml
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning_existing_fs/specs/claim.yaml
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning_existing_fs/specs/pod.yaml
+```
+
+### Check the Application uses FSx for Lustre filesystem
+After the objects are created, verify that pod is running:
+
+```sh
+>> kubectl get pods
+```
+
+Also verify that data is written onto FSx for Luster filesystem:
+
+```sh
+>> kubectl exec -ti fsx-app -- tail -f /data/out.txt
+```

--- a/examples/kubernetes/dynamic_provisioning_existing_fs/specs/claim.yaml
+++ b/examples/kubernetes/dynamic_provisioning_existing_fs/specs/claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc-0d3a
+  resources:
+    requests:
+      storage: 1200Gi

--- a/examples/kubernetes/dynamic_provisioning_existing_fs/specs/pod.yaml
+++ b/examples/kubernetes/dynamic_provisioning_existing_fs/specs/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fsx-app
+spec:
+  containers:
+  - name: app
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: fsx-claim

--- a/examples/kubernetes/dynamic_provisioning_existing_fs/specs/storageclass.yaml
+++ b/examples/kubernetes/dynamic_provisioning_existing_fs/specs/storageclass.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fsx-sc-0d3a
+provisioner: fsx.csi.aws.com
+parameters:
+  fileSystemId: fs-0d3a9c1160a2ef4ad
+mountOptions:
+  - flock

--- a/examples/kubernetes/static_provisioning_with_subpath/README.md
+++ b/examples/kubernetes/static_provisioning_with_subpath/README.md
@@ -1,0 +1,54 @@
+## Static Provisioning Example
+This example shows how to make a pre-created FSx for Lustre filesystem mounted inside container.
+It uses the optional subpath parameter to map a sub-folder of the FSx for Lustre filesystem into the cluster, allowing one filesystem to be used independently by many volumes.
+
+### Edit [Persistent Volume Spec](./specs/pv.yaml)
+```
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fsx-pv
+spec:
+  capacity:
+    storage: 1200Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - flock
+  persistentVolumeReclaimPolicy: Recycle
+  csi:
+    driver: fsx.csi.aws.com
+    volumeHandle: [FileSystemId]
+    volumeAttributes:
+      dnsname: [DNSName]
+      mountname: [MountName]
+      subpath: someDirName
+```
+Replace `volumeHandle` with `FileSystemId`, `dnsname` with `DNSName` and `mountname` with `MountName`. You can get both `FileSystemId`, `DNSName` and `MountName` using AWS CLI:
+When the optional subpath parameter is set, this will create a folder with the name from subpath in the root directory of the FSx filesystem.
+
+```sh
+>> aws fsx describe-file-systems
+```
+
+### Deploy the Application
+Create PV, persistent volume claim (PVC), and the pod that consumes the PV:
+```sh
+>> kubectl apply -f examples/kubernetes/static_provisioning/specs/pv.yaml
+>> kubectl apply -f examples/kubernetes/static_provisioning/specs/claim.yaml
+>> kubectl apply -f examples/kubernetes/static_provisioning/specs/pod.yaml
+```
+
+### Check the Application uses FSx for Lustre filesystem
+After the objects are created, verify that pod is running:
+
+```sh
+>> kubectl get pods
+```
+
+Also verify that data is written onto FSx for Luster filesystem:
+
+```sh
+>> kubectl exec -ti fsx-app -- tail -f /data/out.txt
+```

--- a/examples/kubernetes/static_provisioning_with_subpath/specs/claim.yaml
+++ b/examples/kubernetes/static_provisioning_with_subpath/specs/claim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1200Gi
+  volumeName: fsx-pv

--- a/examples/kubernetes/static_provisioning_with_subpath/specs/pod.yaml
+++ b/examples/kubernetes/static_provisioning_with_subpath/specs/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fsx-app
+spec:
+  containers:
+  - name: app
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: fsx-claim

--- a/examples/kubernetes/static_provisioning_with_subpath/specs/pv.yaml
+++ b/examples/kubernetes/static_provisioning_with_subpath/specs/pv.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fsx-pv
+spec:
+  capacity:
+    storage: 1200Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - flock
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: fsx.csi.aws.com
+    volumeHandle: fs-0199e5a63bd90f796
+    volumeAttributes:
+      dnsname: fs-0199e5a63bd90f796.fsx.us-east-1.amazonaws.com
+      mountname: fsx
+      subpath: somedir

--- a/go.sum
+++ b/go.sum
@@ -753,6 +753,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -37,6 +37,7 @@ var (
 )
 
 const (
+	volumeContextSubPath                      = "subpath"
 	volumeContextDnsName                      = "dnsname"
 	volumeContextMountName                    = "mountname"
 	volumeParamsSubnetId                      = "subnetId"

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -19,8 +19,9 @@ package driver
 import (
 	"context"
 	"errors"
-	"github.com/aws/aws-sdk-go/service/fsx"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/fsx"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
@@ -34,6 +35,7 @@ func TestCreateVolume(t *testing.T) {
 		endpoint               = "endpoint"
 		volumeName             = "volumeName"
 		fileSystemId           = "fs-1234"
+		sharedVolumeId         = "shared/fs-1234/volumeName"
 		volumeSizeGiB    int64 = 1200
 		subnetId               = "subnet-056da83524edbe641"
 		securityGroupIds       = "sg-086f61ea73388fb6b,sg-0145e55e976000c9e"
@@ -272,6 +274,85 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "success: existing fs",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					cloud:    mockCloud,
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					Parameters: map[string]string{
+						volumeParamsFileSystemId: fileSystemId,
+					},
+				}
+
+				ctx := context.Background()
+				fs := &cloud.FileSystem{
+					FileSystemId: fileSystemId,
+					CapacityGiB:  volumeSizeGiB,
+					DnsName:      dnsName,
+					MountName:    mountName,
+				}
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(fs, nil)
+				mockCloud.EXPECT().WaitForFileSystemAvailable(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
+
+				resp, err := driver.CreateVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("CreateVolume is failed: %v", err)
+				}
+
+				if resp.Volume == nil {
+					t.Fatal("resp.Volume is nil")
+				}
+
+				if resp.Volume.VolumeId != sharedVolumeId {
+					t.Fatalf("VolumeId mismatches. actual: %v expected: %v", resp.Volume.VolumeId, fileSystemId)
+				}
+
+				if resp.Volume.CapacityBytes == 0 {
+					t.Fatalf("resp.Volume.CapacityGiB is zero")
+				}
+
+				dnsname, exists := resp.Volume.VolumeContext[volumeContextDnsName]
+				if !exists {
+					t.Fatal("dnsname is missing")
+				}
+
+				if dnsname != dnsName {
+					t.Fatalf("dnsname mismatches. actual: %v expected: %v", dnsname, dnsName)
+				}
+
+				mountname, exists := resp.Volume.VolumeContext[volumeContextMountName]
+				if !exists {
+					t.Fatal("mountname is missing")
+				}
+
+				if mountname != mountName {
+					t.Fatalf("mountname mismatches. actual: %v expected: %v", mountname, mountName)
+				}
+
+				subPath := "volumeName"
+				subpath, exists := resp.Volume.VolumeContext[volumeContextSubPath]
+				if !exists {
+					t.Fatal("subpath is missing")
+				}
+
+				if subpath != subPath {
+					t.Fatalf("subpath mismatches. actual: %v expected: %v", subpath, subPath)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
 			name: "fail: volume name missing",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)
@@ -393,6 +474,38 @@ func TestCreateVolume(t *testing.T) {
 				mockCtl.Finish()
 			},
 		},
+		{
+			name: "fail: DescribeFileSystem return error",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					cloud:    mockCloud,
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					Parameters: map[string]string{
+						volumeParamsFileSystemId: fileSystemId,
+					},
+				}
+
+				ctx := context.Background()
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil, cloud.ErrFsExistsDiffSize)
+
+				_, err := driver.CreateVolume(ctx, req)
+				if err == nil {
+					t.Fatal("CreateVolume is not failed")
+				}
+
+				mockCtl.Finish()
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -402,8 +515,9 @@ func TestCreateVolume(t *testing.T) {
 
 func TestDeleteVolume(t *testing.T) {
 	var (
-		endpoint     = "endpoint"
-		fileSystemId = "fs-1234"
+		endpoint       = "endpoint"
+		fileSystemId   = "fs-1234"
+		sharedVolumeId = "shared/fs-1234/volumeName"
 	)
 	testCases := []struct {
 		name     string
@@ -427,6 +541,31 @@ func TestDeleteVolume(t *testing.T) {
 				ctx := context.Background()
 
 				mockCloud.EXPECT().DeleteFileSystem(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
+				_, err := driver.DeleteVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("DeleteVolume is failed: %v", err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "success: existing filesystem",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					cloud:    mockCloud,
+				}
+
+				req := &csi.DeleteVolumeRequest{
+					VolumeId: sharedVolumeId,
+				}
+
+				ctx := context.Background()
+
 				_, err := driver.DeleteVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("DeleteVolume is failed: %v", err)

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -138,6 +138,11 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	if req.GetReadonly() {
 		mountOptions = append(mountOptions, "ro")
 	}
+	context := req.GetVolumeContext()
+	subpath := context[volumeContextSubPath]
+	if subpath != "" {
+		stagingTarget = fmt.Sprintf("%s/%s", stagingTarget, subpath)
+	}
 
 	klog.V(5).Infof("NodePublishVolume: creating dir %s", target)
 	if err := d.mounter.MakeDir(target); err != nil {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -34,6 +34,7 @@ func TestNodePublishVolume(t *testing.T) {
 		dnsname           = "fs-0a2d0632b5ff567e9.fsx.us-west-2.amazonaws.com"
 		mountname         = "random"
 		targetPath        = "/target/path"
+		subpath           = "subpath"
 		stagingTargetPath = "/staging/target/path"
 		stdVolCap         = &csi.VolumeCapability{
 			AccessType: &csi.VolumeCapability_Mount{
@@ -89,6 +90,23 @@ func TestNodePublishVolume(t *testing.T) {
 			driver: successfulDriverWithOptions([]string{"bind"}),
 			request: func() *csi.NodePublishVolumeRequest {
 				req := standardRequest()
+				return req
+			},
+		},
+		{
+			name: "success: with subpath",
+			driver: func(mockCtrl *gomock.Controller) *Driver {
+				driver, mockMounter := mockDriver(mockCtrl)
+				stagingPathWithSubPath := "/staging/target/path/subpath"
+				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
+				mockMounter.EXPECT().MakeDir(gomock.Eq(stagingPathWithSubPath)).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(stagingPathWithSubPath), gomock.Eq(targetPath), gomock.Eq(""), gomock.Eq([]string{"bind"})).Return(nil)
+
+				return driver
+			},
+			request: func() *csi.NodePublishVolumeRequest {
+				req := standardRequest()
+				req.VolumeContext[volumeContextSubPath] = subpath
 				return req
 			},
 		},

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -50,6 +50,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	fsxDriver.Stop()
 	Expect(os.RemoveAll(socket)).NotTo(HaveOccurred())
+	os.RemoveAll("/tmp/csi")
 })
 
 var _ = Describe("AWS FSx for Lustre CSI Driver", func() {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a new feature, raised in https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/151

**What is this PR about? / Why do we need it?**
This PR is about using an existing Lustre for FSx filesystem across many PersistentVolumes in one namespace.
One part adds in support for mounting a subpath of the filesystem via bind mounts.
The second adds support for setting the FileSystemId in a StorageClass to make setup of PVCs easier.

**What testing is done?** 
I've added relevant unit tests to all sections (And cleaned up the tests some, I'm happy to revert those changes if you'd like, but I think the delta under test is more clear now).

I have run this on a test cluster and applied the example configs and verified it works for my use case.

I HAVE NOT done the e2e tests. I'd like to, but need some help. Is there any documentation for running them? I couldn't get them running from an EC2 instance with basically Administrator access to my AWS account.


**Some questions:**
1. What should the volumeHandle be?
   Currently: shared/<fileSystemId>/<volumeName>
2. Lustre is mounted rw, because we don't have MountOptions in the StageVolumeRequest, does that affect anything? Does the remote filesystem get mount options?
3. I don't know much about flock, is there anything I need to do there with the bind mount.
4. Thoughts on how to clean up old volumes? I'm not sure if we can have the controller mount the filesystem to delete. For now, I'm leaving that as an exercise to the user.